### PR TITLE
Implement vmagent buildpack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
+
+gem 'prometheus-client'
+gem 'puma'
+gem 'rack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,20 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    nio4r (2.5.7)
+    prometheus-client (2.1.0)
+    puma (5.3.2)
+      nio4r (~> 2.0)
+    rack (2.2.3)
+
+PLATFORMS
+  x86_64-darwin-17
+  x86_64-linux
+
+DEPENDENCIES
+  prometheus-client
+  puma
+  rack
+
+BUNDLED WITH
+   2.2.17

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bin/start-vmagent bundle exec rackup config.ru -p ${PORT:-5000}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,147 @@
+# Heroku Buildpack: vmagent
+
+A Heroku buildpack to run the [VictoriaMetrics agent](https://docs.victoriametrics.com/vmagent.html)
+inside a dyno, scrape metrics directly from the app server, and send them to a VictoriaMetrics cluster
+using the Prometheus remote write protocol.
+
+## Usage
+
+Set vmagent config vars on your Heroku app:
+
+```
+$ heroku config:set \
+  VMAGENT_REMOTE_WRITE_URL="https://victoriametrics.example.com" \
+  VMAGENT_REMOTE_WRITE_USERNAME="<vminsert_username>" \
+  VMAGENT_REMOTE_WRITE_PASSWORD="<vminsert_password>"
+```
+
+_See the [Configuration section](#configuration) below for a full list of config vars that can be set._
+
+Add the buildpack to your Heroku app:
+
+```
+$ heroku buildpacks:add https://github.com/ably/heroku-buildpack-vmagent.git
+```
+
+Update your Procfile to run your app server command with the [bin/start-vmagent](bin/start-vmagent) script,
+for example:
+
+```
+web: bin/start-vmagent bundle exec rackup config.ru -p ${PORT:-5000}
+```
+
+Deploy your app, and see that vmagent was installed:
+
+```
+remote: -----> vmagent buildpack app detected
+remote: -----> vmagent-buildpack: Installing vmagent v1.63.0
+remote: -----> vmagent-buildpack: Downloading vmutils from GitHub
+remote: -----> vmagent-buildpack: Extracting vmagent binary
+remote: -----> vmagent-buildpack: Verifying vmagent binary
+remote: vmagent-prod: OK
+remote: -----> vmagent-buildpack: Caching vmagent binary
+remote: -----> vmagent-buildpack: Copying vmagent binary into bin/
+remote: -----> vmagent-buildpack: Copying vmagent start script into bin/
+remote: -----> vmagent-buildpack: Copying vmagent-prometheus.yml.erb into config/
+```
+
+vmagent will now be scraping metrics from the app server and sending them to VictoriaMetrics.
+
+_See [config/vmagent-prometheus.yml.erb](config/vmagent-prometheus.yml.erb) for more information
+on how vmagent is configured to scrape the app server._
+
+## Configuration
+
+#### `VMAGENT_REMOTE_WRITE_URL`
+
+**Required.** The remote write URL to send metrics to.
+
+#### `VMAGENT_REMOTE_WRITE_USERNAME`
+
+**Required.** The basic auth username for the remote write URL.
+
+#### `VMAGENT_REMOTE_WRITE_PASSWORD`
+
+**Required.** The basic auth password for the remote write URL.
+
+#### `VMAGENT_VERSION`
+
+**Optional.** The version of vmagent to install (default: see [bin/vars.sh](bin/vars.sh)).
+
+#### `VMAGENT_SHA256`
+
+**Optional.** The expected SHA256 hash of the vmagent binary (default: see [bin/vars.sh](bin/vars.sh)).
+
+#### `VMAGENT_APP_JOB_NAME`
+
+**Optional.** The job_name used for the app server scrape target (default: web).
+
+#### `VMAGENT_SCRAPE_INTERVAL`
+
+**Optional.** How frequently to scrape metrics from the app server (default: 15s).
+
+#### `VMAGENT_HTTP_PORT`
+
+**Optional.** TCP port vmagent listens on for http connections (default: 8429).
+
+## Testing
+
+This buildpack includes tests that can be run using the [heroku-buildpack-testrunner](https://github.com/heroku/heroku-buildpack-testrunner).
+
+Follow the [testrunner setup instructions](https://github.com/heroku/heroku-buildpack-testrunner#local-setup)
+and then run the tests:
+
+```
+$ bin/run /path/to/heroku-buildpack-vmagent
+
+BUILDPACK: /path/to/heroku-buildpack-vmagent
+  TEST SUITE: compile_test.sh
+  testCompile
+
+  Ran 1 test.
+
+  OK
+  4 SECONDS
+
+  TEST SUITE: detect_test.sh
+  testDetect
+
+  Ran 1 test.
+
+  OK
+  0 SECONDS
+
+  TEST SUITE: release_test.sh
+  testRelease
+
+  Ran 1 test.
+
+  OK
+  1 SECONDS
+
+5 SECONDS
+
+------
+ALL OK
+5 SECONDS
+```
+
+This buildpack also includes a simple Ruby Rack application that can be deployed to
+Heroku along with this buildpack to test metric collection of an app server:
+
+```
+$ heroku create
+
+$ heroku config:set \
+  VMAGENT_REMOTE_WRITE_URL="https://victoriametrics.example.com" \
+  VMAGENT_REMOTE_WRITE_USERNAME="<vminsert_username>" \
+  VMAGENT_REMOTE_WRITE_PASSWORD="<vminsert_password>"
+
+$ heroku buildpacks:add heroku/ruby
+$ heroku buildpacks:add https://github.com/ably/heroku-buildpack-vmagent.git
+
+$ git push heroku main
+```
+
+Visit the resulting Heroku app a few times, and you should see associated metrics appear
+in your VictoriaMetrics cluster.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ on how vmagent is configured to scrape the app server._
 
 **Required.** The basic auth password for the remote write URL.
 
+#### `VMAGENT_EXTERNAL_LABELS`
+
+**Optional.** A comma separated list of additional external labels to add to all metrics in `key=value` format,
+for example `app=my-app,environment=production`.
+
 #### `VMAGENT_VERSION`
 
 **Optional.** The version of vmagent to install (default: see [bin/vars.sh](bin/vars.sh)).

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ for example `app=my-app,environment=production`.
 
 **Optional.** How frequently to scrape metrics from the app server (default: 15s).
 
+#### `VMAGENT_MAX_DISK_USAGE`
+
+**Optional.** The maximum file-based buffer size in bytes that vmagent can use (default: 1GB).
+
 #### `VMAGENT_HTTP_PORT`
 
 **Optional.** TCP port vmagent listens on for http connections (default: 8429).

--- a/bin/compile
+++ b/bin/compile
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -e
+
+BUILD_DIR=$1
+CACHE_DIR=$2
+
+source bin/vars.sh
+
+echo "-----> vmagent-buildpack: Installing vmagent ${VMAGENT_VERSION}"
+
+CACHE_PATH="${CACHE_DIR}/vmagent-${VMAGENT_SHA256}"
+if [[ ! -s "${CACHE_PATH}" ]]; then
+  echo '-----> vmagent-buildpack: Downloading vmutils from GitHub'
+  curl \
+    --silent \
+    --location \
+    --output "vmutils.tgz" \
+    "https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/${VMAGENT_VERSION}/vmutils-amd64-${VMAGENT_VERSION}.tar.gz"
+
+  echo '-----> vmagent-buildpack: Extracting vmagent binary'
+  tar xzf vmutils.tgz vmagent-prod
+  rm vmutils.tgz
+
+  echo '-----> vmagent-buildpack: Verifying vmagent binary'
+  sha256sum --check - <<< "${VMAGENT_SHA256}  vmagent-prod"
+
+  echo '-----> vmagent-buildpack: Caching vmagent binary'
+  mv vmagent-prod "${CACHE_PATH}"
+fi
+
+echo '-----> vmagent-buildpack: Copying vmagent binary into bin/'
+mkdir -p "${BUILD_DIR}/bin"
+cp "${CACHE_PATH}" "${BUILD_DIR}/bin/vmagent"
+chmod +x "${BUILD_DIR}/bin/vmagent"

--- a/bin/compile
+++ b/bin/compile
@@ -33,3 +33,11 @@ echo '-----> vmagent-buildpack: Copying vmagent binary into bin/'
 mkdir -p "${BUILD_DIR}/bin"
 cp "${CACHE_PATH}" "${BUILD_DIR}/bin/vmagent"
 chmod +x "${BUILD_DIR}/bin/vmagent"
+
+echo '-----> vmagent-buildpack: Copying vmagent start script into bin/'
+cp bin/start-vmagent "${BUILD_DIR}/bin/start-vmagent"
+chmod +x "${BUILD_DIR}/bin/start-vmagent"
+
+echo '-----> vmagent-buildpack: Copying vmagent-prometheus.yml.erb into config/'
+mkdir -p "${BUILD_DIR}/config"
+cp config/vmagent-prometheus.yml.erb "${BUILD_DIR}/config/vmagent-prometheus.yml.erb"

--- a/bin/detect
+++ b/bin/detect
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# bin/detect <build-dir>
+echo "vmagent buildpack"
+exit 0

--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+cat <<EOF
+---
+{}
+EOF

--- a/bin/start-vmagent
+++ b/bin/start-vmagent
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# A script to start vmagent and the command passed as ARGV as child processes
+# and wait for either to exit.
+#
+# Inspired by start-nginx from the Heroku nginx buildpack:
+# https://github.com/heroku/heroku-buildpack-nginx/blob/main/bin/start-nginx
+
+psmgr=/tmp/vmagent-buildpack-wait
+rm -f $psmgr
+mkfifo $psmgr
+
+# Render the config file
+erb config/vmagent-prometheus.yml.erb > config/vmagent-prometheus.yml
+
+# Start App Server
+(
+  # Take the command passed to this bin and start it.
+  # E.g. bin/start-vmagent bundle exec unicorn -c config/unicorn.rb
+  COMMAND=$@
+  echo "buildpack=vmagent at=start-app cmd=$COMMAND"
+  $COMMAND
+  echo 'app' >$psmgr
+) &
+
+# Start vmagent
+(
+  echo 'buildpack=vmagent at=start-vmagent'
+  echo -n "${VMAGENT_REMOTE_WRITE_PASSWORD}" > /tmp/vmagent-password
+  bin/vmagent \
+    -promscrape.config=config/vmagent-prometheus.yml \
+    -httpListenAddr=":${VMAGENT_HTTP_PORT:-8429}" \
+    -remoteWrite.url="${VMAGENT_REMOTE_WRITE_URL}/api/v1/write" \
+    -remoteWrite.basicAuth.username="${VMAGENT_REMOTE_WRITE_USERNAME}" \
+    -remoteWrite.basicAuth.passwordFile=/tmp/vmagent-password \
+    -remoteWrite.maxDiskUsagePerURL="1GB"
+  echo 'vmagent' >$psmgr
+) &
+
+# This read will block the process waiting on a msg to be put into the fifo.
+# If any of the processes defined above should exit,
+# a msg will be put into the fifo causing the read operation
+# to un-block. The process putting the msg into the fifo
+# will use it's process name as a msg so that we can print the offending
+# process to stdout.
+read exit_process <$psmgr
+echo "buildpack=vmagent at=exit process=$exit_process"
+exit 1

--- a/bin/start-vmagent
+++ b/bin/start-vmagent
@@ -33,7 +33,7 @@ erb config/vmagent-prometheus.yml.erb > config/vmagent-prometheus.yml
     -remoteWrite.url="${VMAGENT_REMOTE_WRITE_URL}/api/v1/write" \
     -remoteWrite.basicAuth.username="${VMAGENT_REMOTE_WRITE_USERNAME}" \
     -remoteWrite.basicAuth.passwordFile=/tmp/vmagent-password \
-    -remoteWrite.maxDiskUsagePerURL="1GB"
+    -remoteWrite.maxDiskUsagePerURL="${VMAGENT_MAX_DISK_USAGE:-1GB}"
   echo 'vmagent' >$psmgr
 ) &
 

--- a/bin/vars.sh
+++ b/bin/vars.sh
@@ -1,0 +1,8 @@
+# The version of vmagent to install, check https://github.com/VictoriaMetrics/VictoriaMetrics/releases
+VMAGENT_VERSION="${VMAGENT_VERSION:-v1.63.0}"
+
+# The SHA256 hash of the "vmagent-prod" binary extracted from the vmutils archive.
+#
+# The value can be found in the released vmutils checksum file, for example in:
+# https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v1.63.0/vmutils-amd64-v1.63.0_checksums.txt
+VMAGENT_SHA256="${VMAGENT_SHA256:-b2073e0b624f7746334862359608b16327ac7c2d95929838d29637f7903b97cc}"

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,9 @@
+require 'rack'
+require 'prometheus/middleware/collector'
+require 'prometheus/middleware/exporter'
+
+use Rack::Deflater
+use Prometheus::Middleware::Collector
+use Prometheus::Middleware::Exporter
+
+run ->(_) { [200, {'Content-Type' => 'application/json'}, ['"ok"']] }

--- a/config/vmagent-prometheus.yml.erb
+++ b/config/vmagent-prometheus.yml.erb
@@ -1,0 +1,15 @@
+global:
+  scrape_interval: <%= ENV['VMAGENT_SCRAPE_INTERVAL'] || '15s' %>
+
+scrape_configs:
+  - job_name: vmagent
+    static_configs:
+    - targets: ['localhost:<%= ENV['VMAGENT_HTTP_PORT'] || 8429 %>']
+      labels:
+        dyno: <%= ENV['DYNO'] %>
+
+  - job_name: <%= ENV['VMAGENT_APP_JOB_NAME'] || 'web' %>
+    static_configs:
+    - targets: ['localhost:<%= ENV['PORT'] %>']
+      labels:
+        dyno: <%= ENV['DYNO'] %>

--- a/config/vmagent-prometheus.yml.erb
+++ b/config/vmagent-prometheus.yml.erb
@@ -1,15 +1,26 @@
+<%
+require 'json'
+
+external_labels = {
+  dyno: ENV['DYNO'],
+}
+
+if ENV.key?('VMAGENT_EXTERNAL_LABELS')
+  ENV['VMAGENT_EXTERNAL_LABELS'].split(',').each do |label|
+    key, val = label.split('=', 2)
+    external_labels[key] = val
+  end
+end
+%>
 global:
   scrape_interval: <%= ENV['VMAGENT_SCRAPE_INTERVAL'] || '15s' %>
+  external_labels: <%= external_labels.to_json %>
 
 scrape_configs:
   - job_name: vmagent
     static_configs:
     - targets: ['localhost:<%= ENV['VMAGENT_HTTP_PORT'] || 8429 %>']
-      labels:
-        dyno: <%= ENV['DYNO'] %>
 
   - job_name: <%= ENV['VMAGENT_APP_JOB_NAME'] || 'web' %>
     static_configs:
     - targets: ['localhost:<%= ENV['PORT'] %>']
-      labels:
-        dyno: <%= ENV['DYNO'] %>

--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -12,6 +12,8 @@ testCompile() {
   assertCapturedSuccess
   assertCaptured "Installing vmagent ${VMAGENT_VERSION}"
   assertFileExists "${BUILD_DIR}/bin/vmagent"
+  assertFileExists "${BUILD_DIR}/bin/start-vmagent"
+  assertFileExists "${BUILD_DIR}/config/vmagent-prometheus.yml.erb"
   assertFileSHA256 "${VMAGENT_SHA256}" "${BUILD_DIR}/bin/vmagent"
 }
 

--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+. ${BUILDPACK_TEST_RUNNER_HOME}/lib/test_utils.sh
+
+. ${BUILDPACK_HOME}/bin/vars.sh
+
+cd "${BUILDPACK_HOME}"
+
+testCompile() {
+  compile
+
+  assertCapturedSuccess
+  assertCaptured "Installing vmagent ${VMAGENT_VERSION}"
+  assertFileExists "${BUILD_DIR}/bin/vmagent"
+  assertFileSHA256 "${VMAGENT_SHA256}" "${BUILD_DIR}/bin/vmagent"
+}
+
+assertFileExists() {
+  local path=$1
+
+  assertTrue "${path} should exist" "[ -f ${path} ]"
+}
+
+assertFileSHA256() {
+  local sha=$1
+  local path=$2
+
+  assertEquals "${sha}  ${path}" "$(sha256sum "${path}")"
+}

--- a/test/detect_test.sh
+++ b/test/detect_test.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+. ${BUILDPACK_TEST_RUNNER_HOME}/lib/test_utils.sh
+
+testDetect() {
+  detect
+
+  assertCapturedSuccess
+  assertCapturedEquals "vmagent buildpack"
+}

--- a/test/release_test.sh
+++ b/test/release_test.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+. ${BUILDPACK_TEST_RUNNER_HOME}/lib/test_utils.sh
+
+testRelease() {
+  release
+
+  assertCapturedSuccess
+}


### PR DESCRIPTION
This implements the vmagent buildpack which installs and runs the [VictoriaMetrics agent](https://docs.victoriametrics.com/vmagent.html) inside a dyno to scrape metrics directly from the app server and send them to a VictoriaMetrics cluster using the Prometheus remote write protocol.

See the added [README.md](https://github.com/ably/heroku-buildpack-vmagent/tree/buildpack#readme) for further information.