### PR TITLE
Add basic auth config for metrics collection

### DIFF
--- a/config/vmagent-prometheus.yml.erb
+++ b/config/vmagent-prometheus.yml.erb
@@ -24,3 +24,6 @@ scrape_configs:
   - job_name: <%= ENV['VMAGENT_APP_JOB_NAME'] || 'web' %>
     static_configs:
     - targets: ['localhost:<%= ENV['PORT'] %>']
+    basic_auth:
+      username: <%= ENV['VMAGENT_SCRAPE_USERNAME'] %>
+      password: <%= ENV['VMAGENT_SCRAPE_PASSWORD'] %>


### PR DESCRIPTION
 This PR (https://github.com/ably/website/pull/3992) adds basic auth to the `/metrics` endpoint. This PR adds config to the details so the metrics can continue to be collected.