### PR TITLE
allow configuring memory usage and stream mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ for example `app=my-app,environment=production`.
 
 **Optional.** TCP port vmagent listens on for http connections (default: 8429).
 
+#### `VMAGENT_STREAM_PARSE`
+
+**Optional.** Stream parse mode (default: true. see [config/vmagent-prometheus.yml.erb](config/vmagent-prometheus.yml.erb)).
+
+#### `VMAGENT_ALLOWED_BYTES`
+
+**Optional.** Memory allowed bytes (default: 100MB. see [bin/start-vmagent](bin/start-vmagent)).
 ## Testing
 
 This buildpack includes tests that can be run using the [heroku-buildpack-testrunner](https://github.com/heroku/heroku-buildpack-testrunner).

--- a/bin/start-vmagent
+++ b/bin/start-vmagent
@@ -34,6 +34,7 @@ erb config/vmagent-prometheus.yml.erb > config/vmagent-prometheus.yml
   echo -n "${VMAGENT_REMOTE_WRITE_PASSWORD}" > /tmp/vmagent-password
   bin/vmagent \
     -promscrape.config=config/vmagent-prometheus.yml \
+    -memory.allowedBytes="${VMAGENT_ALLOWED_BYTES:-104857600}" \
     -httpListenAddr=":${VMAGENT_HTTP_PORT:-8429}" \
     -remoteWrite.url="${VMAGENT_REMOTE_WRITE_URL}/api/v1/write" \
     -remoteWrite.basicAuth.username="${VMAGENT_REMOTE_WRITE_USERNAME}" \

--- a/config/vmagent-prometheus.yml.erb
+++ b/config/vmagent-prometheus.yml.erb
@@ -22,6 +22,7 @@ scrape_configs:
     - targets: ['localhost:<%= ENV['VMAGENT_HTTP_PORT'] || 8429 %>']
 
   - job_name: <%= ENV['VMAGENT_APP_JOB_NAME'] || 'web' %>
+    stream_parse: <%= ENV.fetch('VMAGENT_STREAM_PARSE', 'true') == 'true' %>
     static_configs:
     - targets: ['localhost:<%= ENV['PORT'] %>']
     basic_auth:


### PR DESCRIPTION
We're seeing runaway memory use on the website since we've enabled Prometheus on all paths. One of the culprits is `vmagent` which has to deal with massive responses from the `/metrics` endpoint, and then balloons in its own memory usage.

This PR adds support for managing stream mode and limiting the memory usage of `vmagent`.

1. memory.allowedBytes set to 100MB by default (our dynos have 1GB)
2. stream mode enabled by default (our metric response bodies are large)